### PR TITLE
Nullable fields decorated

### DIFF
--- a/apps/tax-return/api/src/app/modules/mortgage-interest/dto/create-mortgage-interest.input.ts
+++ b/apps/tax-return/api/src/app/modules/mortgage-interest/dto/create-mortgage-interest.input.ts
@@ -1,5 +1,5 @@
 import { InputType, Int, Field, Float } from '@nestjs/graphql';
-import { IsNumber, IsString } from 'class-validator';
+import { IsNumber, IsOptional, IsString } from 'class-validator';
 
 @InputType()
 export class CreateMortgageInterestInput {
@@ -45,6 +45,7 @@ export class CreateMortgageInterestInput {
   outstandingBalance!: number;
 
   @Field(() => String)
+  @IsOptional()
   @IsString()
   currency!: string;
 }

--- a/apps/tax-return/api/src/app/modules/mortgage-interest/entities/mortgage-interest.entity.ts
+++ b/apps/tax-return/api/src/app/modules/mortgage-interest/entities/mortgage-interest.entity.ts
@@ -7,51 +7,51 @@ export class MortgageInterest {
   @IsString()
   id!: string;
 
-  @Field()
+  @Field({ nullable: true })
   @IsNumber()
   taxSubmissionId?: number;
 
   @IsString()
-  @Field()
+  @Field(() => String, { nullable: true })
   lenderName?: string;
 
   @IsString()
-  @Field()
+  @Field(() => String, { nullable: true })
   type?: string;
 
   @IsString()
-  @Field()
+  @Field(() => String, { nullable: true })
   startDate?: string;
 
-  @Field()
+  @Field({ nullable: true })
   @IsNumber()
   termYears?: number;
 
-  @Field()
+  @Field({ nullable: true })
   @IsNumber()
   purchaseYear?: number;
 
-  @Field()
+  @Field({ nullable: true })
   @IsNumber()
   totalAnnualPayments?: number;
 
-  @Field()
+  @Field({ nullable: true })
   @IsNumber()
   principalRepayment?: number;
 
-  @Field()
+  @Field({ nullable: true })
   @IsNumber()
   interestAmount?: number;
 
-  @Field()
+  @Field({ nullable: true })
   @IsNumber()
   outstandingBalance?: number;
 
-  @Field()
+  @Field({ nullable: true })
   @IsNumber()
   year?: number;
 
-  @Field()
+  @Field(() => String, { nullable: true })
   @IsString()
   currency?: string;
 }

--- a/apps/tax-return/api/src/app/modules/mortgage-interest/mortgage-interest.resolver.spec.ts
+++ b/apps/tax-return/api/src/app/modules/mortgage-interest/mortgage-interest.resolver.spec.ts
@@ -2,6 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { MortgageInterestResolver } from './mortgage-interest.resolver';
 import { BackendAPI } from '../../../services/backend';
 import { CreateMortgageInterestInput } from './dto/create-mortgage-interest.input';
+import { validate } from 'class-validator';
 
 describe('MortgageInterestResolver', () => {
   let resolver: MortgageInterestResolver;
@@ -59,7 +60,6 @@ describe('MortgageInterestResolver', () => {
       principalRepayment: 5000,
       interestAmount: 7000,
       outstandingBalance: 200000,
-      year: 2023,
       currency: 'ISK',
     };
 
@@ -73,6 +73,5 @@ describe('MortgageInterestResolver', () => {
 
     expect(result).toEqual(mockResponse);
     expect(backendApi.createMortgageInterest).toHaveBeenCalledWith(createInput);
-  });
-  
+  });  
 });

--- a/apps/tax-return/api/src/app/modules/other-reliabilities/entities/other-reliability.entity.ts
+++ b/apps/tax-return/api/src/app/modules/other-reliabilities/entities/other-reliability.entity.ts
@@ -5,21 +5,21 @@ export class OtherReliabilities {
   @Field(() => ID)
   id!: number;
 
-  @Field()
+  @Field({ nullable: true })
   taxSubmissionId?: number;
 
-  @Field()
+  @Field(() => String, { nullable: true })
   description?: string;
 
-  @Field()
+  @Field({ nullable: true })
   interestAmount?: number;
 
-  @Field()
+  @Field({ nullable: true })
   balance?: number;
 
-  @Field()
+  @Field({ nullable: true })
   year?: number;
 
-  @Field()
+  @Field(() => String, { nullable: true })
   currency?: string;
 }

--- a/apps/tax-return/api/src/app/modules/pensions-grants-subsidies/entities/pensions-grants-subsidy.entity.ts
+++ b/apps/tax-return/api/src/app/modules/pensions-grants-subsidies/entities/pensions-grants-subsidy.entity.ts
@@ -7,31 +7,31 @@ export class PensionsGrantsSubsidies {
   @IsNumber()
   id!: number;
 
-  @Field()
+  @Field({ nullable: true })
   @IsNumber()
   taxSubmissionId?: number;
 
-  @Field()
+  @Field(() => String, { nullable: true })
   @IsString()
   sourceName?: string;
 
-  @Field()
+  @Field(() => String, { nullable: true })
   @IsString()
   grantType?: string;
 
-  @Field()
+  @Field({ nullable: true })
   @IsNumber()
   amount?: number;
 
-  @Field()
+  @Field(() => String, { nullable: true })
   @IsString()
   currency?: string;
 
-  @Field()
+  @Field(() => String, { nullable: true })
   @IsString()
   description?: string;
 
-  @Field()
+  @Field({ nullable: true })
   @IsNumber()
   year?: number;
 

--- a/apps/tax-return/api/src/app/modules/per-diem-and-perks/entities/per-diem-and-perk.entity.ts
+++ b/apps/tax-return/api/src/app/modules/per-diem-and-perks/entities/per-diem-and-perk.entity.ts
@@ -5,18 +5,18 @@ export class PerDiemAndPerks {
   @Field(() => ID)
   id!: number;
 
-  @Field()
+  @Field({ nullable: true })
   taxSubmissionId?: number;
 
-  @Field()
+  @Field(() => String, { nullable: true })
   type?: string;
 
-  @Field()
+  @Field({ nullable: true })
   amount?: number;
 
-  @Field()
+  @Field(() => String, { nullable: true })
   currency?: string;
 
-  @Field()
+  @Field(() => String, { nullable: true })
   description?: string;
 }

--- a/apps/tax-return/api/src/app/modules/real-estate/entities/real-estate.entity.ts
+++ b/apps/tax-return/api/src/app/modules/real-estate/entities/real-estate.entity.ts
@@ -7,15 +7,15 @@ export class RealEstate {
   @IsString()
   id!: string;
 
-  @Field()
+  @Field({ nullable: true })
   taxSubmissionId?: number;
 
-  @Field()
+  @Field(() => String, { nullable: true })
   address?: string;
 
-  @Field()
+  @Field({ nullable: true })
   assessedValue?: number;
 
-  @Field()
+  @Field(() => String, { nullable: true })
   currency?: string;
 }

--- a/apps/tax-return/api/src/app/modules/salary-work-payments/entities/salary-work-payment.entity.ts
+++ b/apps/tax-return/api/src/app/modules/salary-work-payments/entities/salary-work-payment.entity.ts
@@ -5,21 +5,21 @@ export class SalaryWorkPayments {
   @Field(() => ID)
   id!: number;
 
-  @Field()
+  @Field({ nullable: true })
   taxSubmissionId?: number;
 
-  @Field()
+  @Field(() => String, { nullable: true })
   employerName?: string;
 
-  @Field()
+  @Field({ nullable: true })
   amount?: number;
 
-  @Field()
+  @Field(() => String, { nullable: true })
   currency?: string;
 
-  @Field()
+  @Field(() => String, { nullable: true })
   description?: string;
 
-  @Field()
+  @Field({ nullable: true })
   year?: number;
 }

--- a/apps/tax-return/api/src/app/modules/tax-submission/entities/tax-submission.entity.ts
+++ b/apps/tax-return/api/src/app/modules/tax-submission/entities/tax-submission.entity.ts
@@ -8,15 +8,15 @@ export class TaxSubmission {
   @Field()
   personId!: number
 
-  @Field()
+  @Field({ nullable: true })
   taxYear?: number
 
-  @Field()
+  @Field(() => String, { nullable: true })
   createdAt?: string
 
-  @Field()
+  @Field(() => String, { nullable: true })
   submittedAt?: string
 
-  @Field()
+  @Field(() => String, { nullable: true })
   modified?: string
 }

--- a/apps/tax-return/api/src/app/modules/vehicle/entities/vehicle.entity.ts
+++ b/apps/tax-return/api/src/app/modules/vehicle/entities/vehicle.entity.ts
@@ -5,15 +5,15 @@ export class Vehicle {
   @Field(() => ID)
   id!: string;
 
-  @Field()
+  @Field({ nullable: true })
   taxSubmissionId?: number;
 
-  @Field()
+  @Field({ nullable: true })
   purchaseYear?: number;
 
-  @Field()
+  @Field({ nullable: true })
   purchasePrice?: number;
 
-  @Field()
+  @Field(() => String, { nullable: true })
   currency?: string;
 }

--- a/apps/tax-return/api/src/app/modules/vehicle/vehicle.resolver.spec.ts
+++ b/apps/tax-return/api/src/app/modules/vehicle/vehicle.resolver.spec.ts
@@ -31,14 +31,14 @@ describe('VehicleResolver', () => {
 
   it('should call createVehicle with correct input', async () => {
     const createInput: CreateVehicleInput = {
+      id: 'FMH71',
       taxSubmissionId: 1,
       purchaseYear: 2023,
       purchasePrice: 25000.0,
       currency: 'ISK',
-      year: 2023,
     };
   
-    const mockResponse = { id: '1', ...createInput };
+    const mockResponse = createInput;
     jest.spyOn(backendApi, 'createVehicle').mockResolvedValue(mockResponse);
   
     const result = await resolver.createVehicle(
@@ -49,4 +49,6 @@ describe('VehicleResolver', () => {
     expect(result).toEqual(mockResponse);
     expect(backendApi.createVehicle).toHaveBeenCalledWith(createInput);
   });
+
+  
 })

--- a/apps/tax-return/backend/src/modules/other-reliabilities/other-reliabilities.model.ts
+++ b/apps/tax-return/backend/src/modules/other-reliabilities/other-reliabilities.model.ts
@@ -52,6 +52,7 @@ export class OtherReliabilities extends Model<
 
   @Column({
     type: DataType.STRING(255),
+    allowNull: true
   })
   description!: string;
 
@@ -72,6 +73,7 @@ export class OtherReliabilities extends Model<
 
   @Column({
     type: DataType.CHAR(3),
+    allowNull: true
   })
   currency!: string;
 }

--- a/apps/tax-return/backend/src/modules/subsidy/subsidy.model.ts
+++ b/apps/tax-return/backend/src/modules/subsidy/subsidy.model.ts
@@ -59,12 +59,14 @@ export class Subsidy extends Model<
   amount!: number
 
   @Column({
-    type: DataType.CHAR(3)
+    type: DataType.CHAR(3),
+    allowNull: true
   })
   currency!: string
 
   @Column({
-    type: DataType.STRING(255)
+    type: DataType.STRING(255),
+    allowNull: true
   })
   description!: string
 
@@ -75,13 +77,15 @@ export class Subsidy extends Model<
 
   @Column({
     field: 'source_name',
-    type: DataType.STRING(255)
+    type: DataType.STRING(255),
+    allowNull: true
   })
   sourceName!: string
 
   @Column({
     field: 'grant_type',
-    type: DataType.STRING(100)
+    type: DataType.STRING(100),
+    allowNull: true
   })
   grantType!: string
   


### PR DESCRIPTION
This pull request introduces changes to make several fields across various entities nullable in both the GraphQL schema and the database models. These updates improve flexibility in handling optional data, particularly for fields such as `currency`, `description`, and others. Additionally, minor adjustments were made to test files to align with these changes.

### GraphQL Schema Updates:
* Updated multiple fields in entities like `MortgageInterest`, `OtherReliabilities`, `PensionsGrantsSubsidies`, `RealEstate`, `SalaryWorkPayments`, `Vehicle`, and `TaxSubmission` to be nullable in the GraphQL schema. Examples include `currency`, `description`, `taxSubmissionId`, and others. (`[[1]](diffhunk://#diff-0945d97eb494114d3e0c02beea5727856b461ae01979f62814b5ca81d3d76f0fL10-R54)`, `[[2]](diffhunk://#diff-f175a992cae77f943038a58274d41b781d5334860d84beb28435b0f8b3d6c96aL8-R23)`, `[[3]](diffhunk://#diff-dfa25b78ecf9bde480eebad242c6710347ec12914394021f805574adf08e6e92L10-R34)`, `[[4]](diffhunk://#diff-a8f04f34ad9abec69523389a92a1744c963dc803a293ff28405fb4f73deaba12L8-R20)`, `[[5]](diffhunk://#diff-c0d2fd2c912b12e24e90ac4bf303eb9f72269af4003134f746599b63e7091c44L10-R19)`, `[[6]](diffhunk://#diff-430fc607773cb45ab5084a7ce6e486c8cad33ed06df48c4b53257ff846334380L8-R23)`, `[[7]](diffhunk://#diff-3fe94e23502766701973ae8bb98492a720f67aa62eb23a7eba572429e5594145L11-R20)`, `[[8]](diffhunk://#diff-407594b4631f36e28cb3ef377b40569f79a44f2da716ebcc23661e22df817363L8-R17)`)

### Database Model Updates:
* Made corresponding fields nullable in Sequelize models for entities like `OtherReliabilities` and `Subsidy`. Examples include `currency`, `description`, `sourceName`, and `grantType`. (`[[1]](diffhunk://#diff-4b52b34ac18c937051fed8c88a7b37911115eaf11464060526e7498f5ef38e31R55)`, `[[2]](diffhunk://#diff-4b52b34ac18c937051fed8c88a7b37911115eaf11464060526e7498f5ef38e31R76)`, `[[3]](diffhunk://#diff-c8bc04fe04b1af010e500bb637e4a06984046448e2f77987c2a0eaa0f5f303daL62-R69)`, `[[4]](diffhunk://#diff-c8bc04fe04b1af010e500bb637e4a06984046448e2f77987c2a0eaa0f5f303daL78-R88)`)

### Test Adjustments:
* Updated test cases to reflect changes in the schema, including removing mandatory fields like `year` in `MortgageInterestResolver` and `VehicleResolver`. (`[[1]](diffhunk://#diff-fc6ce933c85308120a96bc9e2d71f4957c33c1e972640ad665d54672f2d40748L62)`, `[[2]](diffhunk://#diff-e0db898b1eee17f45af3f84a0a59043b16fe4bb4e334698c175fa578c18de462R34-R41)`) 
* Added a missing `id` field in a test input for `VehicleResolver`. (`[apps/tax-return/api/src/app/modules/vehicle/vehicle.resolver.spec.tsR34-R41](diffhunk://#diff-e0db898b1eee17f45af3f84a0a59043b16fe4bb4e334698c175fa578c18de462R34-R41)`)

These changes enhance the system's ability to handle optional fields while ensuring consistency across the schema, database models, and test cases
